### PR TITLE
Change cursor color for Light Owl

### DIFF
--- a/schemes.json
+++ b/schemes.json
@@ -33,6 +33,7 @@
             "brightRed": "#DE3D3B",
             "brightWhite": "#979797",
             "brightYellow": "#DAAA01",
+            "cursorColor": "#403F53",
             "cyan": "#2AA298",
             "foreground": "#403F53",
             "green": "#08916A",


### PR DESCRIPTION
The cursor color is hard to see. This PR changes the cursor color to #403F53 which also matches the cursor in VS Code when using Light Owl

![image](https://user-images.githubusercontent.com/69011/99819324-9f4d8300-2b4f-11eb-9b5f-06753401bd83.png)
